### PR TITLE
Add Dockerfile and update to Gradle 7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# vim: ft=gitignore
+# Everything ignored by default
+*
+# Only whitelist what's needed
+!*.gradle
+!docker/
+!gradle/
+!gradlew
+!license*.txt
+!src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,25 +24,15 @@ RUN groupadd --system spring \
     && chown -R spring:spring /app
 USER spring:spring
 
-# TODO: Extract to local file?
-RUN printf '%s\n' '{\
-    "app": {\
-        "storagePath": "/data",\
-        "apiBaseUrl": "http://localhost/api"\
-    },\
-    "server": {\
-        "forward-headers-strategy": "framework",\
-        "port": "8080"\
-    }}' >| dockerdefaults.yaml
+VOLUME /data/storage
 
-VOLUME /data
-
-COPY --from=builder /builddir/build/libs/docker/bibliothek.jar ./
 # We override default config location search path,
 # so that a custom file with defaults can be used
 # Normally would use environment variables,
 # but they take precedence over config file
 # https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
 ENV SPRING_CONFIG_LOCATION="optional:classpath:/,optional:classpath:/config/,file:./dockerdefaults.yaml,optional:file:./,optional:file:./config/"
+COPY ./dockerdefaults.yaml ./dockerdefaults.yaml
 
+COPY --from=builder /builddir/build/libs/docker/bibliothek.jar ./
 CMD ["java", "-jar", "/app/bibliothek.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG JAVA_VERSION=16
 ARG JVM_FLAVOR=hotspot
 
 FROM adoptopenjdk:${JAVA_VERSION}-jdk-${JVM_FLAVOR} AS builder
-WORKDIR /builddir
+WORKDIR /build
 
 COPY gradlew ./
 COPY gradle/ gradle/
@@ -22,7 +22,7 @@ WORKDIR /app
 RUN groupadd --system bibliothek \
     && useradd --system bibliothek --gid bibliothek \
     && chown -R bibliothek:bibliothek /app
-USER spring:spring
+USER bibliothek:bibliothek
 
 VOLUME /data/storage
 EXPOSE 8080
@@ -32,8 +32,8 @@ EXPOSE 8080
 # Normally would use environment variables,
 # but they take precedence over config file
 # https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
-ENV SPRING_CONFIG_LOCATION="optional:classpath:/,optional:classpath:/config/,file:./dockerdefaults.yaml,optional:file:./,optional:file:./config/"
-COPY ./docker/dockerdefaults.yaml ./dockerdefaults.yaml
+ENV SPRING_CONFIG_LOCATION="optional:classpath:/,optional:classpath:/config/,file:./default.application.yaml,optional:file:./,optional:file:./config/"
+COPY ./docker/default.application.yaml ./default.application.yaml
 
-COPY --from=builder /builddir/build/libs/docker/bibliothek.jar ./
+COPY --from=builder /build/build/libs/docker/bibliothek.jar ./
 CMD ["java", "-jar", "/app/bibliothek.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ ARG JVM_FLAVOR=hotspot
 FROM adoptopenjdk:${JAVA_VERSION}-jdk-${JVM_FLAVOR} AS builder
 WORKDIR /builddir
 
-COPY gradlew build.gradle settings.gradle ./
+COPY gradlew ./
 COPY gradle/ gradle/
-RUN ./gradlew --no-daemon # Download gradle and init
+RUN ./gradlew --help --no-daemon # Download gradle and init
 
-COPY license*.txt ./
+COPY license*.txt build.gradle settings.gradle ./
 COPY src/ src/
 RUN ./gradlew clean buildForDocker --no-daemon
 
@@ -19,9 +19,9 @@ ARG JVM_FLAVOR
 FROM adoptopenjdk:${JAVA_VERSION}-jre-${JVM_FLAVOR}
 WORKDIR /app
 
-RUN groupadd --system spring \
-    && useradd --system spring --gid spring \
-    && chown -R spring:spring /app
+RUN groupadd --system bibliothek \
+    && useradd --system bibliothek --gid bibliothek \
+    && chown -R bibliothek:bibliothek /app
 USER spring:spring
 
 VOLUME /data/storage
@@ -33,7 +33,7 @@ EXPOSE 8080
 # but they take precedence over config file
 # https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
 ENV SPRING_CONFIG_LOCATION="optional:classpath:/,optional:classpath:/config/,file:./dockerdefaults.yaml,optional:file:./,optional:file:./config/"
-COPY ./dockerdefaults.yaml ./dockerdefaults.yaml
+COPY ./docker/dockerdefaults.yaml ./dockerdefaults.yaml
 
 COPY --from=builder /builddir/build/libs/docker/bibliothek.jar ./
 CMD ["java", "-jar", "/app/bibliothek.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+ARG JAVA_VERSION=16
+ARG JVM_FLAVOR=hotspot
+
+FROM adoptopenjdk:${JAVA_VERSION}-jdk-${JVM_FLAVOR} AS builder
+WORKDIR /builddir
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle/ gradle/
+RUN ./gradlew --no-daemon # Download gradle and init
+
+COPY license*.txt ./
+COPY src/ src/
+RUN ./gradlew clean buildForDocker --no-daemon
+
+
+ARG JAVA_VERSION
+ARG JVM_FLAVOR
+
+FROM adoptopenjdk:${JAVA_VERSION}-jre-${JVM_FLAVOR}
+WORKDIR /app
+
+RUN groupadd --system spring \
+    && useradd --system spring --gid spring \
+    && chown -R spring:spring /app
+USER spring:spring
+
+# TODO: Extract to local file?
+RUN printf '%s\n' '{\
+    "app": {\
+        "storagePath": "/data",\
+        "apiBaseUrl": "http://localhost/api"\
+    },\
+    "server": {\
+        "forward-headers-strategy": "framework",\
+        "port": "8080"\
+    }}' >| dockerdefaults.yaml
+
+VOLUME /data
+
+COPY --from=builder /builddir/build/libs/docker/bibliothek.jar ./
+# We override default config location search path,
+# so that a custom file with defaults can be used
+# Normally would use environment variables,
+# but they take precedence over config file
+# https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html
+ENV SPRING_CONFIG_LOCATION="optional:classpath:/,optional:classpath:/config/,file:./dockerdefaults.yaml,optional:file:./,optional:file:./config/"
+
+CMD ["java", "-jar", "/app/bibliothek.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN groupadd --system spring \
 USER spring:spring
 
 VOLUME /data/storage
+EXPOSE 8080
 
 # We override default config location search path,
 # so that a custom file with defaults can be used

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,7 @@ ARG JVM_FLAVOR=hotspot
 FROM adoptopenjdk:${JAVA_VERSION}-jdk-${JVM_FLAVOR} AS builder
 WORKDIR /build
 
-COPY gradlew ./
-COPY gradle/ gradle/
-RUN ./gradlew --help --no-daemon # Download gradle and init
-
-COPY license*.txt build.gradle settings.gradle ./
-COPY src/ src/
+COPY ./ ./
 RUN ./gradlew clean buildForDocker --no-daemon
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,18 @@ bootJar {
   launchScript()
 }
 
+// From StackOverflow: https://stackoverflow.com/a/53087407
+// Licensed under: CC BY-SA 4.0
+task buildForDocker(type: Copy){
+  from bootJar
+  into 'build/libs/docker'
+  rename { String fileName ->
+    // a simple way is to remove the "-$version" from the jar filename
+    // but you can customize the filename replacement rule as you wish.
+    fileName.replace("-$project.version", "")
+  }
+}
+
 repositories {
   mavenLocal()
   mavenCentral()

--- a/docker/default.application.yaml
+++ b/docker/default.application.yaml
@@ -1,0 +1,8 @@
+---
+app:
+  # path to volume in Dockerfile - make sure to keep in sync
+  storagePath: "/data/storage"
+  apiBaseUrl: "http://localhost/api"
+server:
+  forward-headers-strategy: "framework"
+  port: 8080

--- a/docker/dockerdefaults.yaml
+++ b/docker/dockerdefaults.yaml
@@ -1,0 +1,9 @@
+---
+# vim: ft=yaml sw=2
+app:
+  # path to volume in Dockerfile - make sure to keep in sync
+  storagePath: /data/storage
+  apiBaseUrl: http://localhost/api
+server:
+  forward-headers-strategy: framework
+  port: '8080'

--- a/docker/dockerdefaults.yaml
+++ b/docker/dockerdefaults.yaml
@@ -1,9 +1,0 @@
----
-# vim: ft=yaml sw=2
-app:
-  # path to volume in Dockerfile - make sure to keep in sync
-  storagePath: /data/storage
-  apiBaseUrl: http://localhost/api
-server:
-  forward-headers-strategy: framework
-  port: '8080'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Multi-Stage building to reduce the size
Spring system user

It comes with sane, containerized defaults and allows for overriding configuration through both ENV vars as well as config files:

```sh
docker run --rm \
  --env SERVER_PORT=6969 \
  -v "${PWD}/application.yaml:/app/application.yaml:ro" \
  bibliothek:latest
```

Not sure where would be the best place to put the `dockerdefaults.yaml` file in the source tree.

Open to questions/suggestions :)

Wanted to handle `docker-compose.yaml` while I'm at it, but I noticed there's no Mongo configuration (it always connects to `localhost:27017`), so I left it out for now.