### PR TITLE
[ci skip] Update depencies for workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - name: "checkout repository"
         uses: "actions/checkout@v3"
       - name: "setup java"
-        uses: "actions/setup-java@v3.6.0"
+        uses: "actions/setup-java@v3"
         with:
           distribution: "zulu"
           java-version: "17"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "setup java"
-        uses: "actions/setup-java@v2"
+        uses: "actions/setup-java@v3.6.0"
         with:
           distribution: "zulu"
           java-version: "17"

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "validate gradle wrapper"
-        uses: "gradle/wrapper-validation-action@v1"
+        uses: "gradle/wrapper-validation-action@v1.0.4"

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -9,4 +9,4 @@ jobs:
       - name: "checkout repository"
         uses: "actions/checkout@v3"
       - name: "validate gradle wrapper"
-        uses: "gradle/wrapper-validation-action@v1.0.5"
+        uses: "gradle/wrapper-validation-action@v1"

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -9,4 +9,4 @@ jobs:
       - name: "checkout repository"
         uses: "actions/checkout@v3"
       - name: "validate gradle wrapper"
-        uses: "gradle/wrapper-validation-action@v1.0.4"
+        uses: "gradle/wrapper-validation-action@v1.0.5"


### PR DESCRIPTION
i forget send the PR xd
Reason: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/