### PR TITLE
Add WebFilter to add CORS headers to all responses

### DIFF
--- a/src/main/java/io/papermc/bibliothek/BibliothekApplication.java
+++ b/src/main/java/io/papermc/bibliothek/BibliothekApplication.java
@@ -27,11 +27,13 @@ import io.papermc.bibliothek.configuration.AppConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 
 @EnableConfigurationProperties({
   AppConfiguration.class
 })
 @SpringBootApplication
+@ServletComponentScan
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class BibliothekApplication {
   public static void main(final String[] args) {

--- a/src/main/java/io/papermc/bibliothek/filter/CorsFilter.java
+++ b/src/main/java/io/papermc/bibliothek/filter/CorsFilter.java
@@ -36,8 +36,8 @@ import java.io.IOException;
 public class CorsFilter implements Filter {
 
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-    HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+  public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
+    final HttpServletResponse httpServletResponse = (HttpServletResponse) response;
     httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");
     httpServletResponse.setHeader("Access-Control-Allow-Methods", "GET");
     chain.doFilter(request, response);

--- a/src/main/java/io/papermc/bibliothek/filter/CorsFilter.java
+++ b/src/main/java/io/papermc/bibliothek/filter/CorsFilter.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of bibliothek, licensed under the MIT License.
+ *
+ * Copyright (c) 2019-2023 PaperMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package io.papermc.bibliothek.filter;
 
 import jakarta.servlet.Filter;
@@ -7,7 +30,6 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.annotation.WebFilter;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 
 @WebFilter("/*")

--- a/src/main/java/io/papermc/bibliothek/filter/CorsFilter.java
+++ b/src/main/java/io/papermc/bibliothek/filter/CorsFilter.java
@@ -1,0 +1,23 @@
+package io.papermc.bibliothek.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebFilter("/*")
+public class CorsFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+    httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");
+    httpServletResponse.setHeader("Access-Control-Allow-Methods", "GET");
+    chain.doFilter(request, response);
+  }
+}


### PR DESCRIPTION
This adds the below headers to every response, so NGINX doesn't need to add them anymore.

Closes #101 

```
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET
```