### PR TITLE
feat: add argument channel for version-controller

### DIFF
--- a/src/main/java/io/papermc/bibliothek/exception/Advice.java
+++ b/src/main/java/io/papermc/bibliothek/exception/Advice.java
@@ -24,6 +24,9 @@
 package io.papermc.bibliothek.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.papermc.bibliothek.database.model.Build;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.EnumUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -70,6 +73,12 @@ class Advice {
   @ResponseBody
   public ResponseEntity<?> versionNotFound(final VersionNotFound exception) {
     return this.error(HttpStatus.NOT_FOUND, "Version not found.");
+  }
+
+  @ExceptionHandler(ChannelNotFound.class)
+  @ResponseBody
+  public ResponseEntity<?> channelNotFound(final ChannelNotFound exception) {
+    return this.error(HttpStatus.NOT_FOUND, "Channel '%s' not found. Only allowed [all,%s]".formatted(exception.getValue(), EnumUtils.getEnumList(Build.Channel.class).stream().map(channel -> channel.toString().toLowerCase()).collect(Collectors.joining(","))));
   }
 
   @ExceptionHandler(NoHandlerFoundException.class)

--- a/src/main/java/io/papermc/bibliothek/exception/ChannelNotFound.java
+++ b/src/main/java/io/papermc/bibliothek/exception/ChannelNotFound.java
@@ -21,23 +21,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.papermc.bibliothek.database.repository;
+package io.papermc.bibliothek.exception;
 
-import io.papermc.bibliothek.database.model.Build;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
+import java.io.Serial;
 
-@Repository
-public interface BuildCollection extends MongoRepository<Build, ObjectId> {
-  List<Build> findAllByProjectAndVersion(final ObjectId project, final ObjectId version);
+public class ChannelNotFound extends RuntimeException {
+  @Serial
+  private static final long serialVersionUID = 1716350953824887164L;
 
-  List<Build> findAllByProjectAndVersionAndChannel(final ObjectId project, final ObjectId version, final String channel);
+  private String value;
 
-  List<Build> findAllByProjectAndVersionIn(final ObjectId project, final Collection<ObjectId> version);
+  public ChannelNotFound(final String value) {
+    super();
+    this.value = value;
+  }
 
-  Optional<Build> findByProjectAndVersionAndNumber(final ObjectId project, final ObjectId version, final int number);
+  @SuppressWarnings("checkstyle:MethodName")
+  public String getValue() {
+    return this.value;
+  }
 }


### PR DESCRIPTION
This PR close #102 with the addition of a filter argument for channel for get builds based in version, for avoid a breaking this PR add the argument like a optional in request (aka filter for "all") this also make the possible errors make more detailed about the valid channels for avoid get empty builds for the bad typing.