### PR TITLE
Allow for more content types for downloads

### DIFF
--- a/src/main/java/io/papermc/bibliothek/controller/v2/DownloadController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/DownloadController.java
@@ -36,6 +36,7 @@ import io.papermc.bibliothek.exception.DownloadNotFound;
 import io.papermc.bibliothek.exception.ProjectNotFound;
 import io.papermc.bibliothek.exception.VersionNotFound;
 import io.papermc.bibliothek.util.HTTP;
+import io.papermc.bibliothek.util.MediaTypes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -107,7 +108,7 @@ public class DownloadController {
     value = "/v2/projects/{project:[a-z]+}/versions/{version:" + Version.PATTERN + "}/builds/{build:\\d+}/downloads/{download:" + Build.Download.PATTERN + "}",
     produces = {
       MediaType.APPLICATION_JSON_VALUE,
-      HTTP.APPLICATION_JAVA_ARCHIVE_VALUE
+      MediaType.ALL_VALUE
     }
   )
   @Operation(summary = "Downloads the given file from a build's data.")
@@ -161,7 +162,7 @@ public class DownloadController {
       final HttpHeaders headers = new HttpHeaders();
       headers.setCacheControl(cache);
       headers.setContentDisposition(HTTP.attachmentDisposition(path.getFileName()));
-      headers.setContentType(HTTP.APPLICATION_JAVA_ARCHIVE);
+      headers.setContentType(MediaTypes.fromFileName(path.getFileName().toString()));
       headers.setLastModified(Files.getLastModifiedTime(path).toInstant());
       return headers;
     }

--- a/src/main/java/io/papermc/bibliothek/util/MediaTypes.java
+++ b/src/main/java/io/papermc/bibliothek/util/MediaTypes.java
@@ -23,28 +23,30 @@
  */
 package io.papermc.bibliothek.util;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.time.Duration;
-import org.springframework.http.CacheControl;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.ResponseEntity;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.http.MediaType;
+import org.springframework.http.MediaTypeFactory;
 
-public final class HTTP {
-  private HTTP() {
+public final class MediaTypes {
+
+  public static final String APPLICATION_ZIP_VALUE = "application/zip";
+  public static final MediaType APPLICATION_ZIP = MediaType.parseMediaType(APPLICATION_ZIP_VALUE);
+
+  private MediaTypes() {
   }
 
-  public static <T> ResponseEntity<T> cachedOk(final T response, final CacheControl cache) {
-    return ResponseEntity.ok().cacheControl(cache).body(response);
+  public static @Nullable MediaType fromFileName(final String name) {
+    final int index = name.lastIndexOf('.');
+    if (index != -1) {
+      return fromFileExtension(name.substring(index + 1));
+    }
+    return null;
   }
 
-  public static CacheControl sMaxAgePublicCache(final Duration sMaxAge) {
-    return CacheControl.empty()
-      .cachePublic()
-      .sMaxAge(sMaxAge);
-  }
-
-  public static ContentDisposition attachmentDisposition(final Path filename) {
-    return ContentDisposition.attachment().filename(filename.getFileName().toString(), StandardCharsets.UTF_8).build();
+  public static @Nullable MediaType fromFileExtension(final String extension) {
+    return switch (extension) {
+      case "mcpack" -> APPLICATION_ZIP;
+      default -> MediaTypeFactory.getMediaType("." + extension).orElse(MediaType.APPLICATION_OCTET_STREAM);
+    };
   }
 }


### PR DESCRIPTION
This moves the static `application/java-archive` content type to picking one based on file extension